### PR TITLE
widget.result.total can be object with key value

### DIFF
--- a/src/Results.js
+++ b/src/Results.js
@@ -10,7 +10,7 @@ export default function({ itemsPerPage, initialPage = 1, pagination, stats, item
   const [page, setPage] = useState(initialPage);
   const widget = widgets.get(id);
   const data = widget && widget.result && widget.result.data ? widget.result.data : [];
-  const total = widget && widget.result && widget.result.total ? widget.result.total : 0;
+  const total = widget && widget.result && widget.result.total ? (widget.result.total.hasOwnProperty('value') ? widget.result.total.value: widget.result.total) : 0;
   itemsPerPage = itemsPerPage || 10;
 
   useEffect(() => {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/177340/106563315-e41c6f80-652b-11eb-8fc2-4184322d01c3.png)

```
{
  "name" : "es-node",
  "version" : {
    "number" : "7.9.2",
    "build_flavor" : "default",
    "build_type" : "docker",
    "build_hash" : "d34da0ea4a966c4e49417f2da2f244e3e97b4e6e",
    "build_date" : "2020-09-23T00:45:33.626720Z",
    "build_snapshot" : false,
    "lucene_version" : "8.6.2",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  },
  "tagline" : "You Know, for Search"
}
